### PR TITLE
update index list on load and catch  empty index load error

### DIFF
--- a/web/src/components/search/IndexList.vue
+++ b/web/src/components/search/IndexList.vue
@@ -160,6 +160,7 @@ export default defineComponent({
 
     // get the list of indices from server when the component is mounted
     const getIndexList = () => {
+      indexList.value = [];
       indexService.list().then((res) => {
         res.data.map((item) => {
           indexList.value.push({
@@ -180,6 +181,7 @@ export default defineComponent({
       filterFn,
       selectFn,
       indexFields,
+      getIndexList,
       cachedFields,
       filterField,
       filterFieldFn,

--- a/web/src/components/search/SearchResult.vue
+++ b/web/src/components/search/SearchResult.vue
@@ -515,6 +515,10 @@ export default defineComponent({
               });
             });
           });
+        })
+        .catch((err) => { // handle the errors so as to continue using the applications
+          console.log(err.message);
+          searchLoading.value = false;
         });
     };
 

--- a/web/src/views/Search.vue
+++ b/web/src/views/Search.vue
@@ -8,28 +8,33 @@
         @refresh="searchData"
       />
       <div class="row">
-        <index-list ref="indexList" :data="indexData" @updated="indexUpdated" />
-        <search-list ref="searchList" @updated:fields="updateIndexFields" />
+        <index-list ref="indexListRef" :data="indexData" @updated="indexUpdated" />
+        <search-result ref="searchResultRef" @updated:fields="updateIndexFields" />
       </div>
     </div>
   </q-page>
 </template>
 
 <script>
-import { defineComponent, ref } from "vue";
+import { defineComponent, onUpdated, ref } from "vue";
 
 import SearchBar from "../components/search/SearchBar.vue";
 import IndexList from "../components/search/IndexList.vue";
-import SearchList from "../components/search/SearchList.vue";
+import SearchResult from "../components/search/SearchResult.vue";
 
 export default defineComponent({
   name: "PageSearch",
   components: {
     SearchBar,
     IndexList,
-    SearchList,
+    SearchResult,
   },
+
   setup() {
+    onUpdated(() => {
+      updateIndexList(); // update the index list without hard page refresh whenever the page is updated
+    });
+
     const indexData = ref({
       name: "",
       columns: [],
@@ -49,13 +54,19 @@ export default defineComponent({
     });
 
     const searchBar = ref(null);
-    const indexList = ref(null);
-    const searchList = ref(null);
+    const indexListRef = ref(null);
+    const searchResultRef = ref(null);
     const searchData = () => {
-      searchList.value.searchData(indexData.value, queryData.value);
+      searchResultRef.value.searchData(indexData.value, queryData.value);
     };
+
+    const updateIndexList = () => {
+      indexListRef.value.getIndexList();
+    };
+
+
     const resetColumns = () => {
-      searchList.value.resetColumns(indexData.value);
+      searchResultRef.value.resetColumns(indexData.value);
     };
 
     const indexUpdated = ({ name, columns }) => {
@@ -78,15 +89,15 @@ export default defineComponent({
     };
 
     const updateIndexFields = (fields) => {
-      indexList.value.setIndexFields(fields);
+      indexListRef.value.setIndexFields(fields);
     };
 
     return {
       indexData,
       queryData,
       searchBar,
-      indexList,
-      searchList,
+      indexListRef,
+      searchResultRef,
       searchData,
       indexUpdated,
       queryUpdated,


### PR DESCRIPTION
Handling 2 things:

1. Now when a new index is created it does not require a hard reload of page to load indexes.
2. Catching the error when an attempt to query a newly created empty index is made so as to be able to continue using app"