### PR TITLE
feat: Added override of default Sentry DSN

### DIFF
--- a/cmd/zinc/main.go
+++ b/cmd/zinc/main.go
@@ -45,10 +45,10 @@ import (
 // @BasePath  /api
 func main() {
 
-	if config.Global.SentryEnable {
+	if config.Global.SentryEnable && config.Global.SentryDSN != "" {
 		/******** initialize sentry **********/
 		err := sentry.Init(sentry.ClientOptions{
-			Dsn:     "https://15b6d9b8be824b44896f32b0234c32b7@o1218932.ingest.sentry.io/6360942",
+			Dsn:     config.Global.SentryDSN,
 			Release: "zinc@" + meta.Version,
 		})
 		if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,7 @@ type config struct {
 	NodeID               string `env:"ZINC_NODE_ID,default=1"`
 	DataPath             string `env:"ZINC_DATA_PATH,default=./data"`
 	SentryEnable         bool   `env:"ZINC_SENTRY,default=true"`
+	SentryDSN            string `env:"ZINC_SENTRY_DSN,default=https://15b6d9b8be824b44896f32b0234c32b7@o1218932.ingest.sentry.io/6360942"`
 	TelemetryEnable      bool   `env:"ZINC_TELEMETRY,default=true"`
 	PrometheusEnable     bool   `env:"ZINC_PROMETHEUS_ENABLE,default=false"`
 	BatchSize            int    `env:"ZINC_BATCH_SIZE,default=1024"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -41,6 +41,7 @@ func TestConfig(t *testing.T) {
 		assert.Equal(t, "x", c.NodeID)
 		assert.Equal(t, "./data", c.DataPath)
 		assert.Equal(t, true, c.SentryEnable)
+		assert.Equal(t, "https://15b6d9b8be824b44896f32b0234c32b7@o1218932.ingest.sentry.io/6360942", c.SentryDSN) // Add check for default value
 		assert.Equal(t, true, c.TelemetryEnable)
 		assert.Equal(t, false, c.PrometheusEnable)
 
@@ -56,5 +57,21 @@ func TestConfig(t *testing.T) {
 		assert.Equal(t, false, c.Plugin.GSE.Enable)
 		assert.Equal(t, "small", c.Plugin.GSE.DictEmbed)
 		assert.Equal(t, "./plugins/gse/dict", c.Plugin.GSE.DictPath)
+	})
+}
+
+func TestSentryDSNOverride(t *testing.T) {
+	customDSN := "https://secretToken.my.sentry.com/1234"
+
+	t.Run("prepare", func(t *testing.T) {
+		os.Setenv("ZINC_SENTRY_DSN", customDSN)
+	})
+
+	t.Run("check", func(t *testing.T) {
+		c := new(config)
+		rv := reflect.ValueOf(c).Elem()
+		loadConfig(rv)
+
+		assert.Equal(t, customDSN, c.SentryDSN)
 	})
 }


### PR DESCRIPTION
This adds Sentry DSN from a new env variable, `ZINC_SENTRY_DSN`, which probably needs to be documented. 
This allows users to capture Zinc errors in their own sentry deployments and not risk leaking sensitive data.