### PR TITLE
fix multiple ascii regex match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ miniodata
 *.so
 *.dylib
 .env
-
+.idea
 # Test binary, built with `go test -c`
 *.test
 

--- a/pkg/handlers/index/delete.go
+++ b/pkg/handlers/index/delete.go
@@ -72,7 +72,7 @@ func deleteIndexWithWildcard(indexName string, indexList []*core.Index) error {
 	for i, part := range parts {
 		pattern += part
 		if i < len(parts)-1 {
-			pattern += "[[:ascii:]]"
+			pattern += "[[:ascii:]]+"
 		}
 	}
 

--- a/pkg/handlers/index/delete_test.go
+++ b/pkg/handlers/index/delete_test.go
@@ -64,6 +64,15 @@ func TestDelete(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "index does not exist",
+			args: args{
+				code:   http.StatusBadRequest,
+				params: map[string]string{"target": "Index-Not-Exists"},
+				result: "index Index-Not-Exists does not exists",
+			},
+			wantErr: false,
+		},
 	}
 
 	t.Run("prepare", func(t *testing.T) {


### PR DESCRIPTION
This PR fixes the wildcard index name match.

`"[[:ascii:]]"` to `"[[:ascii:]]+"`
