### PR TITLE
Ingress API for latest kubernete version (+1.24)

### DIFF
--- a/helm/zinc/Chart.yaml
+++ b/helm/zinc/Chart.yaml
@@ -3,6 +3,6 @@ name: zinc
 description: Zinc is a search engine that does full text indexing. It is a lightweight alternative to Elasticsearch and runs in less than 100 MB of RAM.
 type: application
 version: 0.1.0
-appVersion: v0.1.1
+appVersion: v0.2.6
 sources:
-  - https://github.com/prabhatsharma/zinc
+  - https://github.com/zinclabs/zinc

--- a/helm/zinc/templates/ingress.yaml
+++ b/helm/zinc/templates/ingress.yaml
@@ -35,6 +35,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:

--- a/helm/zinc/templates/ingress.yaml
+++ b/helm/zinc/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "zinc.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -34,8 +36,15 @@ spec:
           {{- range .paths }}
           - path: {{ . }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+              {{- end }}
           {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
The helm provided in `helm/zinc` does not work for my kubernetes cluster (+1.24).  The issue was caused by ingress class being deprecated, so I updated to work with latest version. 
