### PR TITLE
Add persistent location with proper permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG BUILD_DATE
 
 RUN update-ca-certificates
 # RUN apk update && apk add --no-cache git
-# Create zinc.
+# Create zinc user.
 ENV USER=zinc
 ENV GROUP=zinc
 ENV UID=10001
@@ -37,9 +37,10 @@ RUN adduser \
     --uid "${UID}" \
     --gid "${GID}" \
     "${USER}"
-# Default directory for persistent Zinc data used in final build stage. It follows the Linux filesystem hierarchy pattern
+# Create default directories for persistent Zinc data used in final build stage.
+# It follows the Linux filesystem hierarchy pattern
 # https://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/var.html
-RUN mkdir -p /var/lib/zinc && chown zinc:zinc /var/lib/zinc
+RUN mkdir -p /var/lib/zinc /data && chown zinc:zinc /var/lib/zinc /data
 WORKDIR $GOPATH/src/github.com/zinclabs/zinc/
 COPY . .
 COPY --from=webBuilder /web/dist web/dist
@@ -79,12 +80,9 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 # Copy our static executable.
 COPY --from=builder  /go/src/github.com/zinclabs/zinc/zinc /go/bin/zinc
 
-# Create directory that can be used to keep Zinc data persistent along with host source or named volumes
+# Create directories that can be used to keep Zinc data persistent along with host source or named volumes
 COPY --from=builder --chown=zinc:zinc /var/lib/zinc /var/lib/zinc
-
-# Default directory for persistent Zinc data. It follows the Linux filesystem hierarchy pattern
-# https://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/var.html
-ENV ZINC_DATA_PATH=/var/lib/zinc
+COPY --from=builder --chown=zinc:zinc /data /data
 
 # Use an unprivileged user.
 USER zinc:zinc

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -24,10 +24,13 @@ ARG TARGETARCH
 
 RUN update-ca-certificates
 # RUN apk update && apk add --no-cache git
-# Create appuser.
-ENV USER=appuser
+# Create zinc user.
+ENV USER=zinc
+ENV GROUP=zinc
 ENV UID=10001
+ENV GID=10001
 # See https://stackoverflow.com/a/55757473/12429735RUN
+RUN groupadd --gid "${GID}" "${GROUP}"
 RUN adduser \
     --disabled-password \
     --gecos "" \
@@ -35,11 +38,16 @@ RUN adduser \
     --shell "/sbin/nologin" \
     --no-create-home \
     --uid "${UID}" \
+    --gid "${GID}" \
     "${USER}"
+# Create default directories for persistent Zinc data used in final build stage.
+# It follows the Linux filesystem hierarchy pattern
+# https://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/var.html
+RUN mkdir -p /var/lib/zinc /data && chown zinc:zinc /var/lib/zinc /data
 WORKDIR $GOPATH/src/github.com/zinclabs/zinc/
 
 # Copy the whole repo to the current directory. This includes prebuilt front end assets. in web/dist folder
-COPY . .    
+COPY . .
 # COPY --from=webBuilder /web/dist web/dist
 
 # Fetch dependencies.
@@ -76,8 +84,12 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 # Copy our static executable.
 COPY --from=builder  /go/src/github.com/zinclabs/zinc/zinc /go/bin/zinc
 
+# Create directories that can be used to keep Zinc data persistent along with host source or named volumes
+COPY --from=builder --chown=zinc:zinc /var/lib/zinc /var/lib/zinc
+COPY --from=builder --chown=zinc:zinc /data /data
+
 # Use an unprivileged user.
-USER appuser:appuser
+USER zinc:zinc
 # Port on which the service will be exposed.
 EXPOSE 4080
 # Run the zinc binary.

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -22,10 +22,13 @@ ARG TARGETARCH
 
 RUN update-ca-certificates
 # RUN apk update && apk add --no-cache git
-# Create appuser.
-ENV USER=appuser
+# Create zinc user.
+ENV USER=zinc
+ENV GROUP=zinc
 ENV UID=10001
+ENV GID=10001
 # See https://stackoverflow.com/a/55757473/12429735RUN
+RUN groupadd --gid "${GID}" "${GROUP}"
 RUN adduser \
     --disabled-password \
     --gecos "" \
@@ -33,7 +36,12 @@ RUN adduser \
     --shell "/sbin/nologin" \
     --no-create-home \
     --uid "${UID}" \
+    --gid "${GID}" \
     "${USER}"
+# Create default directories for persistent Zinc data used in final build stage.
+# It follows the Linux filesystem hierarchy pattern
+# https://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/var.html
+RUN mkdir -p /var/lib/zinc /data && chown zinc:zinc /var/lib/zinc /data
 WORKDIR $GOPATH/src/github.com/zinclabs/zinc/
 
 COPY . .
@@ -73,8 +81,12 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 # Copy our static executable.
 COPY --from=builder  /go/src/github.com/zinclabs/zinc/zinc /go/bin/zinc
 
+# Create directories that can be used to keep Zinc data persistent along with host source or named volumes
+COPY --from=builder --chown=zinc:zinc /var/lib/zinc /var/lib/zinc
+COPY --from=builder --chown=zinc:zinc /data /data
+
 # Use an unprivileged user.
-USER appuser:appuser
+USER zinc:zinc
 # Port on which the service will be exposed.
 EXPOSE 4080
 # Run the zinc binary.


### PR DESCRIPTION
It fixes #512

Changed user and group to zinc:zinc to match general convention used in other services like rabbitmq, mysql, etc..

Added default ZINC_DATA_PATH=/var/lib/zinc. It follows Linux filesystem hierarchy convention:

https://tldp.org/LDP/Linux-Filesystem-Hierarchy/html/var.html