### PR TITLE
Fix growing url paths on refresh

### DIFF
--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -70,7 +70,7 @@ const routes = [
 ];
 
 const router = createRouter({
-  history: createWebHistory(window.location.pathname),
+  history: createWebHistory(),
   routes,
 });
 


### PR DESCRIPTION
This fixes the growing path on refresh. For example when you're on /search and you refresh you will find /search/search in the url bar.