### PR TITLE
Add codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/zinclabs/zinc)](https://goreportcard.com/report/github.com/zinclabs/zinc)
-[![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://join.slack.com/t/zinc-nvh4832/shared_invite/zt-11r96hv2b-UwxUILuSJ1duzl_6mhJwVg) [![Docs](https://img.shields.io/badge/Docs-Docs-green)](https://docs.zincsearch.com/)
+[![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://join.slack.com/t/zinc-nvh4832/shared_invite/zt-11r96hv2b-UwxUILuSJ1duzl_6mhJwVg) [![Docs](https://img.shields.io/badge/Docs-Docs-green)](https://docs.zincsearch.com/) [![codecov](https://codecov.io/github/zinclabs/zinc/branch/main/graph/badge.svg)](https://codecov.io/github/zinclabs/zinc)
 
 # Zinc Search Engine
 


### PR DESCRIPTION
I Added a codecov badge to the README so that the community can see the code coverage number for zinc.

### What it looks like:

<img width="430" alt="Screen Shot 2022-10-18 at 10 45 29" src="https://user-images.githubusercontent.com/69668484/196505892-dd5add48-853d-4424-b941-1096b244e497.png">
